### PR TITLE
Compile linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 
 # Project specific files
 *.sublime-workspace
+*.dvi
+*.fls
+*.out.ps
+*.pyg

--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,14 @@ OPEN ?= $(shell which open)
 PLATFORM ?= $(shell uname)
 
 ifeq ($(PLATFORM),Linux)
-include Makefile.linux
+override OPEN=$(shell which gnome-open)
 endif
 
-OUTDIR=.
-LTX_FLAGS=-shell-escape -output-directory $(OUTDIR)
+LTX_FLAGS=-shell-escape -pdf
 
 REPORT=main.tex
 
-report: setup
+report:
 	$(LTX) $(LTX_FLAGS) $(REPORT)
 	$(GLS) $(OUTDIR)/$(REPORT:.tex=)
 	$(LTX) $(LTX_FLAGS) $(REPORT)
@@ -30,9 +29,6 @@ show: report
 
 showquick: quick
 	$(OPEN) $(OUTDIR)/$(REPORT:.tex=.pdf)
-
-setup:
-	@if [ ! -d $(OUTDIR) ]; then mkdir $(OUTDIR); fi
 
 clean:
 	@rm -rf *.aux

--- a/Makefile
+++ b/Makefile
@@ -14,21 +14,21 @@ REPORT=main.tex
 
 report:
 	$(LTX) $(LTX_FLAGS) $(REPORT)
-	$(GLS) $(OUTDIR)/$(REPORT:.tex=)
+	$(GLS) $(REPORT:.tex=)
 	$(LTX) $(LTX_FLAGS) $(REPORT)
-	$(BTX) $(OUTDIR)/$(REPORT:.tex=.aux)
+	$(BTX) $(REPORT:.tex=.aux)
 	$(LTX) $(LTX_FLAGS) $(REPORT)
-	$(GLS) $(OUTDIR)/$(REPORT:.tex=)
+	$(GLS) $(REPORT:.tex=)
 	$(LTX) $(LTX_FLAGS) $(REPORT)
 
 quick:
 	$(LTX) $(LTX_FLAGS) $(REPORT)
 
 show: report
-	$(OPEN) $(OUTDIR)/$(REPORT:.tex=.pdf)
+	$(OPEN) $(REPORT:.tex=.pdf)
 
 showquick: quick
-	$(OPEN) $(OUTDIR)/$(REPORT:.tex=.pdf)
+	$(OPEN) $(REPORT:.tex=.pdf)
 
 clean:
 	@rm -rf *.aux

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ include Makefile.linux
 endif
 
 OUTDIR=.
-LTX_FLAGS=-output-directory $(OUTDIR)
+LTX_FLAGS=-shell-escape -output-directory $(OUTDIR)
 
 REPORT=main.tex
 

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,1 +1,0 @@
-override OPEN=$(shell which gnome-open)

--- a/commands.tex
+++ b/commands.tex
@@ -1,6 +1,6 @@
 
 % Different todo colors
-\newcommand{\todocite}[1]{\todo[color=green!40]{#1}}
+\newcommandx{\todocite}[2][1=]{\todo[linecolor=OliveGreen,backgroundcolor=OliveGreen!25,bordercolor=OliveGreen,#1]{#2}}
 
 % Used in order to get the desired kind of abbreviations. I think...
 \renewcommand{\glossarysection}[2][]{}

--- a/main.tex
+++ b/main.tex
@@ -21,7 +21,6 @@
   \include{background/background}
   \include{methodology/methodology}
   \include{results/results}
-  \include{conclusion/discussion}
   \include{conclusion/conclusion}
 
   % The bibliography can be generated from multiple sources.

--- a/packages.tex
+++ b/packages.tex
@@ -1,9 +1,21 @@
 \usepackage[utf8]{inputenc}
 \usepackage[english]{babel}
-\usepackage{lipsum}
+
+% More defined colors, used for custom todos
+\usepackage[pdftex,dvipsnames]{xcolor}
+
+% Used for new commands taking more than one argument
+\usepackage{xargs}
 
 % For orange todos
 \usepackage{todonotes}
+
+% Lorem ipsum
+\usepackage{lipsum}
+
+% For b5 papers instead of a4
+\usepackage{geometry}
+\geometry{b5paper}
 
 % Multirow and multicolumn tables
 \usepackage{multirow}
@@ -64,3 +76,7 @@
 
 % \usepackage{pgfplots}
 % \usepackage[nottoc]{tocbibind}
+
+% For listings. This package requires the pdf to be compiled with '-shell-escape' and that
+% python-pygments is found in the system path
+\usepackage{minted}


### PR DESCRIPTION
- Added minted-package. This requires the pdf to be compiled with `-shell-escape` and that `python-pygments` is installed on the system. This package supports Rust, among others, and is easier to use than `lstlistings` (e.g. color highlighting by default).
- Removed the `out-dir` from makefile, as it is not in use. 
- Included the one line from `Makefile.linux` directly into this Makefile and deleted `Makefile.linux`.
- Compile the document as `b5` instead of `a4`, as this is the format of NTNU master's.
- Ignored several other files that gets auto-generated.
