### PR TITLE
More bugs

### DIFF
--- a/conclusion/conclusion.tex
+++ b/conclusion/conclusion.tex
@@ -28,8 +28,8 @@ Throughout \autoref{chap:results} we presented our results of measuring the {\rg
 As we presented in \autoref{sub:interfacing_with_emlib} the platform consists of partially finished bindings.
 An obvious extension to our project is to continue and finalize the binding libraries for the {\emlib}, {\emdrv} and \gls{cmsis} libraries.
 The foundations for these binding have been laid out, so the implementations here are not challenging, only time-consuming.
-An alternative approach is to use a bindings generator such as \lib{bindgen} \footnote{https://github.com/crabtw/rust-bindgen} to generate the binding automatically.
-The binding effort might be redundant altogether, as the {\rust} roadmap \footnote{https://internals.rust-lang.org/t/priorities-after-1-0/1901} states that the project wants to develop better integration with {\C}/{\Cpp} code.
+An alternative approach is to use a bindings generator such as \lib{bindgen}\footnote{\url{https://github.com/crabtw/rust-bindgen}} to generate the binding automatically.
+The binding effort might be redundant altogether, as the {\rust} roadmap states that the project wants to develop better integration with {\C}/{\Cpp} code \cite{web:roadmap}.
 This might eventually lead to bindings like these being made obsolete, and that {\C} libraries can called into based on their header files, alone.
 
 As discussed in \autoref{sec:disc:rust_for_arm}, we found the current basis for writing reusable libraries to be limiting for our platform.

--- a/front/preface.tex
+++ b/front/preface.tex
@@ -1,4 +1,8 @@
 
+\newcommand\textbox[1]{%
+  \parbox{.45\textwidth}{#1}%
+}
+
 \chapter{Preface}
 \label{chap:preface}
 
@@ -7,7 +11,7 @@ This report is submitted to the Norwegian University of Science and Technology i
 This work has been performed at the Department of Computer and Information Science, NTNU, with Prof. Magnus Lie Hetland as the supervisor, Antonio Garcia Guirado (ARM), and Marius Grannæs (Silicon Labs) as co-supervisors.
 The initial problem description was our own proposal and further developed in co-operation with our supervisors.
 
-\paragraph{Acknowledgements} \\ \hfill
+\paragraph{Acknowledgements} \hfill
 
 Thanks to Magnus Lie Hetland, Antonio Garcia Guirado, and Marius Grannæs for directions and guidance on technical issues and this report.
 Thanks to Silicon Labs for providing us with development platforms for us to develop and test our implementation on.

--- a/implementation/interfacing_with_emlib.tex
+++ b/implementation/interfacing_with_emlib.tex
@@ -437,7 +437,7 @@ It shows a test case that is used to verify that the \texttt{ADC\_Init} function
 \begin{listing}[H]
   \centering
   \begin{minipage}{\textwidth}
-  \begin{listing}
+  \begin{listing}[H]
     \begin{rustcode}
 fn test_init_called_with_default() {
   // FFI call to the C function below
@@ -454,7 +454,7 @@ fn test_init_called_with_default() {
   \end{minipage}
 
   \begin{minipage}{\textwidth}
-  \begin{listing}
+  \begin{listing}[H]
     \begin{ccode}
 void adc_expect_init_called_with_default() {
   static ADC_Init_TypeDef init = ADC_INIT_DEFAULT;

--- a/implementation/objectoriented.tex
+++ b/implementation/objectoriented.tex
@@ -72,7 +72,7 @@ Objects in a language like {\Java} also includes a tag field at the base of the 
 \begin{listing}[H]
   \centering
   \begin{minipage}{0.26\textwidth}
-  \begin{listing}
+  \begin{listing}[H]
     \begin{javacode}
 class ADC {
   int CTRL;
@@ -88,7 +88,7 @@ class ADC {
   \end{minipage}
   \hfill
   \begin{minipage}{0.33\textwidth}
-  \begin{listing}
+  \begin{listing}[H]
     \begin{ccode}
 typedef struct {
   uint32_t CTRL;
@@ -104,7 +104,7 @@ typedef struct {
   \end{minipage}
   \hfill
   \begin{minipage}{0.27\textwidth}
-  \begin{listing}
+  \begin{listing}[H]
     \begin{rustcode}
 #[repr(C)]
 struct ADC {
@@ -160,11 +160,9 @@ The memory layout of these objects is given in \autoref{fig:back:memlayout}.
       0x24&SINGLEDATA\\ \hline
       ...&...        \\ \hline
     \end{tabular}
-        \caption{{\C}}
+    \caption{{\C}}
     \label{fig:back:memlayout:c}
   \end{subfigure}
-  \caption{Memory layout of objects}
-  \label{fig:back:memlayout}
   \hfill
   \begin{subfigure}{0.31\textwidth}
     \begin{tabular}{|l|l|}
@@ -177,9 +175,11 @@ The memory layout of these objects is given in \autoref{fig:back:memlayout}.
       0x24&SINGLEDATA\\ \hline
       ...&...        \\ \hline
     \end{tabular}
-    \caption{\rust}
+    \caption{{\rust}}
     \label{fig:back:memlayout:rust}
   \end{subfigure}
+  \caption{Memory layout of objects}
+  \label{fig:back:memlayout}
 
 \end{figure}
 
@@ -207,7 +207,7 @@ The function then uses the object reference in the same manner as the implicit \
 \begin{listing}[H]
   \centering
   \begin{minipage}{0.47\textwidth}
-  \begin{listing}
+  \begin{listing}[H]
       \begin{ccode}
 // ADC Member function with
 // explicit object reference
@@ -232,7 +232,7 @@ void main() {
   \end{minipage}
   \hfill
   \begin{minipage}{0.47\textwidth}
-  \begin{listing}
+  \begin{listing}[H]
       \begin{rustcode}
 impl Adc {
   // Rust lets the programmer
@@ -280,7 +280,7 @@ Therefore the constructor-destructor pattern is not applicable for \gls{mmio}s, 
 \begin{listing}[H]
   \hfill
   \begin{minipage}{0.45\textwidth}
-  \begin{listing}
+  \begin{listing}[H]
     \begin{ccode}
 #define ADC0_BASE 0x40002000
 
@@ -292,7 +292,7 @@ void main() {
   \end{listing}
   \end{minipage}
   \begin{minipage}{0.46\textwidth}
-  \begin{listing}
+  \begin{listing}[H]
     \begin{rustcode}
 const ADC0_BASE: *mut Adc
       = 0x40002000 as *mut Adc;

--- a/refs/library.bib
+++ b/refs/library.bib
@@ -151,12 +151,12 @@ year = {2014}
 }
 
 @article{PetitBianco,
-  author = {Alexandre Petit-Bianco}
+  author = {Alexandre Petit-Bianco},
   title ={{No Silver Bullet - Garbage Collection for Java in Embedded Systems}}
 }
 
 @article{Pizlo,
   author = {Filip Pizlo, Lukasz Ziarek, Jan Vitek},
-  title = {Real Time Java on resource-constrained platforms with Fiji VM},
+  title = {{Real Time Java on resource-constrained platforms with Fiji VM}},
   year = {2009}
 }

--- a/refs/web.bib
+++ b/refs/web.bib
@@ -97,3 +97,8 @@
   howpublished = {Available: \url{https://gcc.gnu.org/onlinedocs/}},
   note = {[Accessed: 2015-06-11]}
 }
+@msic{web:roadmap,
+  title = {{Priorities after 1.0}},
+  howpublished = {Available: \url{https://internals.rust-lang.org/t/priorities-after-1-0/1901}},
+  note = {[Accessed: 2015-06-14]}
+}


### PR DESCRIPTION
- La til rust roadmap som cite istedet for footnote. Trodde kanskje dette var gjort allerede, men vi har kanskje glemt det?
- La til textbox kommandoen slik at datoen right-alignes, fikser #118 
- Fikset feil i bibliografi
- Gjort det slik at kode i minipage ikke lager error
- Fikset plassering av caption slik at tabellene i `objectoriented` kommer ved siden av hverandre
